### PR TITLE
updated query to get city name instead of county name

### DIFF
--- a/src/components/widgets/ChorloplethMap/index.tsx
+++ b/src/components/widgets/ChorloplethMap/index.tsx
@@ -38,7 +38,7 @@ export const ChorloplethMap = () => {
     const div = d3.select('#tooltip');
     div.style('opacity', 0.9);
     div
-      .html(`<strong>City: ${d.name}<br/> Count: ${d.population}</strong>`)
+      .html(`<strong>Location: ${d.name}<br/> Contributors: ${d.population}</strong>`)
       .style('left', event.pageX + 10 + 'px')
       .style('top', event.pageY - 12 + 'px')
       .style('position', 'absolute');

--- a/src/layout/MainLayout/SideBar/WorksetWidget.tsx
+++ b/src/layout/MainLayout/SideBar/WorksetWidget.tsx
@@ -69,7 +69,7 @@ const WorksetWidget = () => {
             values += ` <${viafid_chunk[n]}>`;
           }
         }
-        const sparqlQuery = `SELECT ?item ?countryiso ?coordinates ?dob ?cityLabel ?cityCoords
+        const sparqlQuery = `SELECT ?item ?countryiso ?cityCoords ?cityLabel ?dob
                               WHERE {
                               VALUES ?item { ${values} }
                               ?person wdtn:P214 ?item .
@@ -77,13 +77,12 @@ const WorksetWidget = () => {
                               ?pob_entry ps:P19 ?pob .
                               ?pob_entry a wikibase:BestRank .
                                 OPTIONAL { ?pob p:P17/ps:P17/wdt:P299 ?countryiso .}
-                                OPTIONAL { ?pob p:P625/ps:P625 ?coordinates .}
+                                OPTIONAL { ?pob wdt:P625 ?cityCoords ;
+                                                rdfs:label ?cityLabel . 
+                                            FILTER(lang(?cityLabel) = 'en') .}
                                 OPTIONAL { ?person p:P569 ?dob_entry . 
                                           ?dob_entry ps:P569 ?dob .
                                           ?dob_entry a wikibase:BestRank . }
-                                OPTIONAL { ?pob wdt:P131 ?city .
-                                          ?city wdt:P625 ?cityCoords .
-                                          SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". } }
                             }`;
         //let ran = getRandomInt(Math.floor(viafids.length / 50));
         await new Promise((r) => setTimeout(r, 10 * viafids.length * 0.2));


### PR DESCRIPTION
Updated query to get english ?pob label, rather than the label for P131, which is an entity that contains the place of birth.

Also coordinates were being queried for twice, so dropped one of those.