### PR TITLE
Ht style -- fonts and colors

### DIFF
--- a/src/components/@extended/LoadingButton.tsx
+++ b/src/components/@extended/LoadingButton.tsx
@@ -198,7 +198,7 @@ const LoadingButtonStyle = styled(MuiLoadingButton, { shouldForwardProp: (prop) 
     }),
     ...((variant === 'contained' || variant === 'shadow') &&
       !loading && {
-        color: '#fff'
+        color: theme.palette.common.white/*'#fff'*/
       }),
     ...(variant !== 'text' && {
       ...getColorStyle({ variant, theme, color, loadingPosition })

--- a/src/components/Backdrop.tsx
+++ b/src/components/Backdrop.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
-import { Backdrop, CircularProgress } from '@mui/material';
+import { Backdrop, CircularProgress, useTheme } from '@mui/material';
 
 interface IBackDrop {
   loading: boolean;
 }
 
 const CustomBackdrop = ({ loading }: IBackDrop) => {
+  const theme = useTheme();
   return (
-    <Backdrop sx={{ color: '#fff', zIndex: (theme) => theme.zIndex.drawer + 1 }} open={loading}>
+    <Backdrop sx={{ color: theme.palette.common.white/*'#fff'*/, zIndex: (theme) => theme.zIndex.drawer + 1 }} open={loading}>
       <CircularProgress color="inherit" />
     </Backdrop>
   );

--- a/src/components/CustomSlider.tsx
+++ b/src/components/CustomSlider.tsx
@@ -33,7 +33,7 @@ const CustomSlider = ({ value, minValue, maxValue, step, handleSliderChange }: I
           onChange={handleSliderChange}
           valueLabelDisplay="auto"
           sx={{
-            color: '#1e98d7',
+            color: theme.palette.primary[700]/*'#1e98d7'*/,
             '.MuiSlider-thumb': {
               backgroundColor: theme.palette.common.white,
               width: theme.spacing(3.75),

--- a/src/components/widgets/WidgetTitle.tsx
+++ b/src/components/widgets/WidgetTitle.tsx
@@ -1,4 +1,4 @@
-import { Typography } from '@mui/material';
+import { Typography, useTheme } from '@mui/material';
 import NextLink from 'next/link';
 import { WidgetTitles } from 'data/constants';
 
@@ -8,15 +8,23 @@ type WidgetTitleProps = {
 };
 
 const WidgetTitle = ({ widgetType, isDetailsPage }: WidgetTitleProps) => {
+  const theme = useTheme();
   return (
     <>
       {isDetailsPage ? (
-        <Typography variant="h3" sx={{ color: '#1e98d7' }}>
+        <Typography variant="h3" sx={{ color: theme.palette.mode === 'light' ? theme.palette.primary[700]/*'#1e98d7'*/ : theme.palette.common.white }}>
           {WidgetTitles[widgetType]}
         </Typography>
       ) : (
         <NextLink href={`/widget-details/${widgetType}`}>
-          <Typography variant="h3" sx={{ color: '#1e98d7', cursor: 'pointer' }}>
+          <Typography 
+            variant="h3" 
+            sx = {{ 
+              color: theme.palette.mode === 'light' ? theme.palette.primary[700]/*'#1e98d7'*/ : theme.palette.common.white, 
+              cursor: 'pointer', 
+              '&:hover': {color: theme.palette.primary.main} 
+              }}
+          >
             {WidgetTitles[widgetType]}
           </Typography>
         </NextLink>

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,7 +9,7 @@ export const DRAWER_WIDTH = 360;
 // ==============================|| THEME CONFIG  ||============================== //
 
 const config: DefaultConfigProps = {
-  fontFamily: `'Public Sans', sans-serif`,
+  fontFamily: `'Questrial', sans-serif`,
   i18n: 'en',
   menuOrientation: 'vertical',
   miniDrawer: false,

--- a/src/layout/MainLayout/Header/HeaderContent/Profile/index.tsx
+++ b/src/layout/MainLayout/Header/HeaderContent/Profile/index.tsx
@@ -176,7 +176,7 @@ const Profile = () => {
               width: '120px',
               height: '36px',
               borderRadius: '4px',
-              backgroundColor: '#1e98d7',
+              backgroundColor: '#73787A'/*'#1e98d7'*/,
               boxSizing: 'border-box',
               color: '#ffffff',
               textAlign: 'center',

--- a/src/layout/MainLayout/Header/HeaderContent/Profile/index.tsx
+++ b/src/layout/MainLayout/Header/HeaderContent/Profile/index.tsx
@@ -176,9 +176,9 @@ const Profile = () => {
               width: '120px',
               height: '36px',
               borderRadius: '4px',
-              backgroundColor: '#73787A'/*'#1e98d7'*/,
+              backgroundColor: /*'#73787A'/*'#1e98d7'*/ theme.palette.primary[700],
               boxSizing: 'border-box',
-              color: '#ffffff',
+              color: theme.palette.common.white/*'#ffffff'*/,
               textAlign: 'center',
               lineHeight: 'normal'
             }}

--- a/src/layout/MainLayout/SideBar/CleanDataWidget.tsx
+++ b/src/layout/MainLayout/SideBar/CleanDataWidget.tsx
@@ -91,7 +91,7 @@ const CleanDataWidget = () => {
               <FormControlLabel value="default" control={<Radio color="secondary" />} label="Use default" />
               <a
                 style={{
-                  color: '#1e98d7',
+                  color: theme.palette.primary[700]/*'#1e98d7'*/,
                   textAlign: 'center',
                   lineHeight: 'normal',
                   cursor: 'pointer'
@@ -111,7 +111,7 @@ const CleanDataWidget = () => {
                   height: '21px',
                   padding: '2px',
                   borderRadius: '10px',
-                  backgroundColor: '#1e98d7',
+                  backgroundColor: theme.palette.primary[700]/*'#1e98d7'*/,
                   color: theme.palette.common.white,
                   textAlign: 'center',
                   lineHeight: 'normal'
@@ -202,7 +202,7 @@ const CleanDataWidget = () => {
               height: theme.spacing(5),
               padding: theme.spacing(0.25),
               borderRadius: '15px',
-              backgroundColor: '#1e98d7',
+              backgroundColor: theme.palette.primary[700]/*'#1e98d7'*/,
               fontFamily: "'ArialMT', 'Arial', 'sans-serif'",
               fontSize: theme.spacing(1.625),
               color: theme.palette.common.white,

--- a/src/layout/MainLayout/SideBar/DataFilterWidget.tsx
+++ b/src/layout/MainLayout/SideBar/DataFilterWidget.tsx
@@ -244,7 +244,7 @@ const DataFilterWidget = () => {
               height: theme.spacing(5),
               padding: theme.spacing(0.25),
               borderRadius: '15px',
-              backgroundColor: '#1e98d7',
+              backgroundColor: theme.palette.primary[700]/*'#1e98d7'*/,
               fontFamily: "'ArialMT', 'Arial', 'sans-serif'",
               fontSize: theme.spacing(1.625),
               color: theme.palette.common.white,

--- a/src/layout/MainLayout/SideBar/DownloadWidget.tsx
+++ b/src/layout/MainLayout/SideBar/DownloadWidget.tsx
@@ -58,7 +58,7 @@ const CleanDataWidget = () => {
               height: theme.spacing(5),
               padding: theme.spacing(0.25),
               borderRadius: '15px',
-              backgroundColor: '#1e98d7',
+              backgroundColor: theme.palette.primary[700]/*'#1e98d7'*/,
               fontFamily: "'ArialMT', 'Arial', 'sans-serif'",
               fontSize: theme.spacing(1.625),
               color: theme.palette.common.white,

--- a/src/layout/MainLayout/SideBar/index.tsx
+++ b/src/layout/MainLayout/SideBar/index.tsx
@@ -36,10 +36,10 @@ const SideBar = () => {
           },
           '& .MuiAccordionSummary-expandIconWrapper': { display: 'none' },
           '& .Mui-expanded': {
-            color: '#1e98d7',
+            color: theme.palette.mode === 'light'? theme.palette.common.black/*'#1e98d7'*/ : theme.palette.common.white,
             backgroundColor: theme.palette.mode === 'light' ? theme.palette.grey[200] : 'inherit'
           },
-          '& h5:hover': { color: '#1e98d7' }
+          '& h5:hover': { color: theme.palette.primary.main/*'#1e98d7'*/ }
         }
       }}
     >

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -12,7 +12,7 @@ export default function Document() {
         <link rel="shortcut icon" href="/favicon.svg" />
         <link rel="preconnect" href="https://fonts.gstatic.com" />
         <link
-          href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Poppins:wght@400;500;600;700&family=Roboto:wght@400;500;700&display=swap&family=Public+Sans:wght@400;500;600;700"
+          href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Poppins:wght@400;500;600;700&family=Roboto:wght@400;500;700&display=swap&family=Public+Sans:wght@400;500;600;700?family=Questrial&display=swap?family=Domine:wght@400;500;600;700&display=swap"
           rel="stylesheet"
         />
         {/* eslint-disable-next-line @next/next/no-sync-scripts */}

--- a/src/themes/overrides/Button.ts
+++ b/src/themes/overrides/Button.ts
@@ -56,11 +56,10 @@ function getColorStyle({ variant, color, theme }: ButtonStyleProps) {
     case 'outlined':
       return {
         borderColor: main,
-        /*backgroundColor: 'transparent',*/
         '&:hover': {
-          color: dark,
+          color: theme.palette.mode === 'light' ? dark : theme.palette.common.white,
           backgroundColor: 'transparent',
-          borderColor: dark
+          borderColor: theme.palette.mode === 'light' ? dark : theme.palette.common.white
         },
         ...commonShadow
       };

--- a/src/themes/overrides/Button.ts
+++ b/src/themes/overrides/Button.ts
@@ -38,7 +38,7 @@ function getColorStyle({ variant, color, theme }: ButtonStyleProps) {
     case 'contained':
       return {
         '&:hover': {
-          backgroundColor: dark
+          backgroundColor: main/*dark*/
         },
         ...commonShadow
       };
@@ -56,6 +56,7 @@ function getColorStyle({ variant, color, theme }: ButtonStyleProps) {
     case 'outlined':
       return {
         borderColor: main,
+        /*backgroundColor: 'transparent',*/
         '&:hover': {
           color: dark,
           backgroundColor: 'transparent',
@@ -91,6 +92,7 @@ function getColorStyle({ variant, color, theme }: ButtonStyleProps) {
 export default function Button(theme: Theme) {
   const primaryDashed = getColorStyle({ variant: 'dashed', color: 'primary', theme });
   const primaryShadow = getColorStyle({ variant: 'shadow', color: 'primary', theme });
+  const primaryContained = getColorStyle({ variant: 'contained', color: 'primary', theme });
 
   const disabledStyle = {
     '&.Mui-disabled': {
@@ -110,7 +112,7 @@ export default function Button(theme: Theme) {
       },
       styleOverrides: {
         root: {
-          fontWeight: 400,
+          fontWeight: 800/*400*/,
           '&::after': {
             content: '""',
             display: 'block',

--- a/src/themes/overrides/Switch.ts
+++ b/src/themes/overrides/Switch.ts
@@ -65,7 +65,7 @@ export default function Switch(theme: Theme) {
         },
         switchBase: {
           '&.Mui-checked': {
-            color: '#fff',
+            color: theme.palette.common.white/*'#fff'*/,
             '& + .MuiSwitch-track': {
               opacity: 1
             },

--- a/src/themes/theme/default.ts
+++ b/src/themes/theme/default.ts
@@ -1,23 +1,9 @@
 // types
 import { PaletteThemeProps } from 'types/theme';
 import { PalettesProps } from '@ant-design/colors';
-import { PaletteColorOptions, ThemeOptions } from '@mui/material/styles';
+import { PaletteColorOptions } from '@mui/material/styles';
 
 // ==============================|| PRESET THEME - DEFAULT ||============================== //
-
-//Jenny added ThemeOptions
-export const themeOptions: ThemeOptions = {
-  palette: {
-    mode: 'light',
-    primary: {
-      main: '#C35400',
-    },
-    secondary: {
-      main: '#505759',
-      light: '#73787A' //this is taken from the Material UI Theme Creator https://zenoo.github.io/mui-theme-creator/#Buttons
-    },
-  },
-};
 
 const Default = (colors: PalettesProps): PaletteThemeProps => {
   const { blue, red, gold, cyan, green, grey } = colors;
@@ -51,9 +37,9 @@ const Default = (colors: PalettesProps): PaletteThemeProps => {
       400: blue[4],
       main: '#C35400'/*blue[5]*/,
       dark: '#73787A'/*blue[6]*/,
-      700: blue[7],
+      700: '#73787A'/*blue[7]*/,
       darker: blue[8],
-      900: blue[9],
+      900: '#505759'/*blue[9]*/,
       contrastText
     },
     secondary: {

--- a/src/themes/theme/default.ts
+++ b/src/themes/theme/default.ts
@@ -1,9 +1,23 @@
 // types
 import { PaletteThemeProps } from 'types/theme';
 import { PalettesProps } from '@ant-design/colors';
-import { PaletteColorOptions } from '@mui/material/styles';
+import { PaletteColorOptions, ThemeOptions } from '@mui/material/styles';
 
 // ==============================|| PRESET THEME - DEFAULT ||============================== //
+
+//Jenny added ThemeOptions
+export const themeOptions: ThemeOptions = {
+  palette: {
+    mode: 'light',
+    primary: {
+      main: '#C35400',
+    },
+    secondary: {
+      main: '#505759',
+      light: '#73787A' //this is taken from the Material UI Theme Creator https://zenoo.github.io/mui-theme-creator/#Buttons
+    },
+  },
+};
 
 const Default = (colors: PalettesProps): PaletteThemeProps => {
   const { blue, red, gold, cyan, green, grey } = colors;
@@ -30,13 +44,13 @@ const Default = (colors: PalettesProps): PaletteThemeProps => {
 
   return {
     primary: {
-      lighter: blue[0],
+      lighter: '#73787A'/*blue[0]*/,
       100: blue[1],
       200: blue[2],
       light: blue[3],
       400: blue[4],
-      main: blue[5],
-      dark: blue[6],
+      main: '#C35400'/*blue[5]*/,
+      dark: '#73787A'/*blue[6]*/,
       700: blue[7],
       darker: blue[8],
       900: blue[9],

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -2,7 +2,7 @@ export type ThemeDirection = 'ltr' | 'rtl';
 export type ThemeMode = 'light' | 'dark';
 export type MenuOrientation = 'vertical' | 'horizontal';
 
-export type FontFamily = `'Inter', sans-serif` | `'Poppins', sans-serif` | `'Roboto', sans-serif` | `'Public Sans', sans-serif`;
+export type FontFamily = `'Inter', sans-serif` | `'Poppins', sans-serif` | `'Roboto', sans-serif` | `'Public Sans', sans-serif` | `'Questrial', sans-serif` | `'Domine', serif`;
 export type PresetColor = 'default' | 'theme1' | 'theme2' | 'theme3' | 'theme4' | 'theme5' | 'theme6' | 'theme7' | 'theme8';
 export type I18n = 'en' | 'fr' | 'ro' | 'zh'; // 'en' - English, 'fr' - French, 'ro' - Romanian, 'zh' - Chinese
 
@@ -26,6 +26,7 @@ export type DefaultConfigProps = {
    * `'Poppins', sans-serif`
    * `'Roboto', sans-serif`
    * `'Public Sans', sans-serif` (default)
+   * have manually added two Google fonts: Questrial and Domine
    */
   fontFamily: FontFamily;
 


### PR DESCRIPTION
1. HathiTrust brand fonts `'Questrial', sans-serif` and`'Domine', serif` have been added to the src/theme/config.ts file
2. HathiTurst brand colors have been added to the primary palette in src/themes/theme/default.ts
3. Various pages' IU components' colors have been updated to use the palette object keys to specify colors (in some cases depending on 'mode' (i.e., 'light' or 'dark')) INSTEAD of hard-coded hex values.