### PR TITLE
Widget Polish

### DIFF
--- a/src/components/CustomSlider.tsx
+++ b/src/components/CustomSlider.tsx
@@ -1,5 +1,6 @@
 import { Slider, Stack, Typography, useTheme } from '@mui/material';
 interface ISlider {
+  label: string;
   value: number[];
   minValue: number;
   maxValue: number;
@@ -7,19 +8,19 @@ interface ISlider {
   handleSliderChange: (event: any) => void;
 }
 
-const CustomSlider = ({ value, minValue, maxValue, step, handleSliderChange }: ISlider) => {
+const CustomSlider = ({ label, value, minValue, maxValue, step, handleSliderChange }: ISlider) => {
   const theme = useTheme();
   return (
     <Stack sx={{ width: '100%', mt: 3 }} alignItems="start">
-      <Typography color="secondary">Adjust years on map</Typography>
+      <Typography color="secondary">{label}</Typography>
       <Stack sx={{ width: '100%' }} direction="row" justifyContent="space-between">
         <Stack alignItems="center">
           <Typography>Min</Typography>
-          {minValue == 0 ? '' : <Typography>{minValue}</Typography>}
+          {minValue == 0 ? '' : minValue < 0 ? <Typography>{minValue * -1} BCE</Typography> : <Typography>{minValue}</Typography>}
         </Stack>
         <Stack alignItems="center">
           <Typography>Max</Typography>
-          {maxValue == 0 ? '' : <Typography>{maxValue}</Typography>}
+          {maxValue == 0 ? '' : maxValue < 0 ? <Typography>{maxValue * -1} BCE</Typography> : minValue < 0 ? <Typography>{maxValue} CE</Typography> : <Typography>{maxValue}</Typography>}
         </Stack>
       </Stack>
       {maxValue == 0 ? (

--- a/src/components/CustomTableRow.tsx
+++ b/src/components/CustomTableRow.tsx
@@ -29,9 +29,10 @@ const CustomTableRow = ({ item, handleSelectWorkSet, selected }: ICustomTableRow
               width: 15,
               maxHeight: { xs: 15, md: 15 },
               maxWidth: { xs: 15, md: 15 },
-              position: 'absolute',
+              position: 'sticky',
               top: '10px',
-              right: '10px'
+              right: '10px',
+              float: 'right'
             }}
             alt={item.description}
             src={theme.palette.mode === 'dark' ? '/images/info_white.png' : '/images/info.png'}

--- a/src/components/widgets/ChorloplethMap/index.tsx
+++ b/src/components/widgets/ChorloplethMap/index.tsx
@@ -412,7 +412,7 @@ export const ChorloplethMap = ({ data, widgetType, isDetailsPage = false }) => {
       .attr('class', 'marker')
       .attr('cx', (d) => projection(d.coordinates)[0])
       .attr('cy', (d) => projection(d.coordinates)[1])
-      .attr('r', (d) => (8 / maxPopulation) * d.population)
+      .attr('r', (d) => (10 / maxPopulation) * d.population > 1 ? (10 / maxPopulation) * d.population : 1)
       // .attr('r', (d) => (maxPopulation > 8 ? (8 / maxPopulation) * d.population : d.population * 1.5))
       .each(function (d) {
         d.initialRadius = d3.select(this).attr('r');

--- a/src/components/widgets/ChorloplethMap/index.tsx
+++ b/src/components/widgets/ChorloplethMap/index.tsx
@@ -550,7 +550,7 @@ export const ChorloplethMap = ({ data, widgetType, isDetailsPage = false }) => {
       )}
       <Box sx={{ width: '100%', position: 'relative' }}>
         <div id="graph-container" ref={inputRef} />
-        <CustomSlider value={dateRange} minValue={minYear} maxValue={maxYear} step={10} handleSliderChange={handleSliderChange} />
+        <CustomSlider label="Adjust contributor birth years on map" value={dateRange} minValue={minYear} maxValue={maxYear} step={10} handleSliderChange={handleSliderChange} />
       </Box>
     </>
   );

--- a/src/components/widgets/ChorloplethMap/index.tsx
+++ b/src/components/widgets/ChorloplethMap/index.tsx
@@ -412,7 +412,7 @@ export const ChorloplethMap = ({ data, widgetType, isDetailsPage = false }) => {
       .attr('class', 'marker')
       .attr('cx', (d) => projection(d.coordinates)[0])
       .attr('cy', (d) => projection(d.coordinates)[1])
-      .attr('r', (d) => (10 / maxPopulation) * d.population > 1 ? (10 / maxPopulation) * d.population : 1)
+      .attr('r', (d) => (8 / maxPopulation) * d.population > 1 ? (8 / maxPopulation) * d.population : 1)
       // .attr('r', (d) => (maxPopulation > 8 ? (8 / maxPopulation) * d.population : d.population * 1.5))
       .each(function (d) {
         d.initialRadius = d3.select(this).attr('r');

--- a/src/components/widgets/PublicationTimeLineChart/index.tsx
+++ b/src/components/widgets/PublicationTimeLineChart/index.tsx
@@ -75,7 +75,15 @@ export const PublicationTimeLineChart = ({ data, widgetType, isDetailsPage = fal
     const svgElement = d3.select(axesRef.current);
     svgElement.selectAll('*').remove();
 
-    const xAxisGenerator = d3.axisBottom(xScaleHistogram).tickFormat((d) => Math.round(d));
+    const xAxisGenerator = d3.axisBottom(xScaleHistogram);
+    const dateSpread = dateRange[1]-dateRange[0];
+    if (dateSpread < 10) {
+      xAxisGenerator.ticks(dateSpread).tickFormat((d) => Math.round(d));
+    }
+    else {
+      xAxisGenerator.tickFormat((d) => Math.round(d));
+    }
+
     svgElement
       .append('g')
       .attr('transform', 'translate(0,' + boundsHeight + ')')
@@ -90,7 +98,7 @@ export const PublicationTimeLineChart = ({ data, widgetType, isDetailsPage = fal
       yAxisGenerator.ticks().tickFormat(d3.format('~d'));
     }
     svgElement.append('g').call(yAxisGenerator);
-  }, [xScaleHistogram, yScaleHistogram, boundsHeight, maxDataValue]);
+  }, [xScaleHistogram, yScaleHistogram, boundsHeight, maxDataValue, dateRange]);
 
   const allRects = chartDataHistogram.map((bucket, i) => {
     return (

--- a/src/components/widgets/PublicationTimeLineChart/index.tsx
+++ b/src/components/widgets/PublicationTimeLineChart/index.tsx
@@ -69,7 +69,7 @@ export const PublicationTimeLineChart = ({ data, widgetType, isDetailsPage = fal
   const xScaleHistogram = d3.scaleLinear().domain([dateRange[0], dateRange[1]]).range([0, boundsWidth]);
   //y-axis scale for Histogram
   const maxDataValue = Math.max(...data.map((item) => item.count));
-  const yScaleHistogram: any = d3.scaleLinear().domain([0, maxDataValue]).range([boundsHeight, 0]);
+  const yScaleHistogram: any = d3.scaleLinear().domain([0, maxDataValue]).range([boundsHeight, 0]).nice();
 
   useEffect(() => {
     const svgElement = d3.select(axesRef.current);
@@ -82,7 +82,13 @@ export const PublicationTimeLineChart = ({ data, widgetType, isDetailsPage = fal
       .call(xAxisGenerator);
 
     // @ts-ignore
-    const yAxisGenerator: any = d3.axisLeft(yScaleHistogram).ticks(maxDataValue).tickFormat(d3.format('~d'));
+    const yAxisGenerator: any = d3.axisLeft(yScaleHistogram)
+    if (maxDataValue < 10) {
+      yAxisGenerator.ticks(maxDataValue).tickFormat(d3.format('~d'));
+    }
+    else {
+      yAxisGenerator.ticks().tickFormat(d3.format('~d'));
+    }
     svgElement.append('g').call(yAxisGenerator);
   }, [xScaleHistogram, yScaleHistogram, boundsHeight, maxDataValue]);
 

--- a/src/components/widgets/PublicationTimeLineChart/index.tsx
+++ b/src/components/widgets/PublicationTimeLineChart/index.tsx
@@ -66,7 +66,7 @@ export const PublicationTimeLineChart = ({ data, widgetType, isDetailsPage = fal
   const boundsHeight = height - MARGIN.top - MARGIN.bottom;
 
   //x-axis scale for Histogram
-  const xScaleHistogram = d3.scaleLinear().domain([dateRange[0], dateRange[1]]).range([0, boundsWidth]);
+  const xScaleHistogram = d3.scaleLinear().domain([dateRange[0], dateRange[1]+1]).range([0, boundsWidth]);
   //y-axis scale for Histogram
   const maxDataValue = Math.max(...data.map((item) => item.count));
   const yScaleHistogram: any = d3.scaleLinear().domain([0, maxDataValue]).range([boundsHeight, 0]).nice();
@@ -76,17 +76,16 @@ export const PublicationTimeLineChart = ({ data, widgetType, isDetailsPage = fal
     svgElement.selectAll('*').remove();
 
     const xAxisGenerator = d3.axisBottom(xScaleHistogram);
-    const dateSpread = dateRange[1]-dateRange[0];
+    const dateSpread = dateRange[1] - dateRange[0];
     if (dateSpread < 10) {
       xAxisGenerator.ticks(dateSpread).tickFormat((d) => Math.round(d));
     }
     else {
       xAxisGenerator.tickFormat((d) => Math.round(d));
     }
-
     svgElement
       .append('g')
-      .attr('transform', 'translate(0,' + boundsHeight + ')')
+      .attr('transform', `translate(0,${boundsHeight})`)
       .call(xAxisGenerator);
 
     // @ts-ignore
@@ -106,7 +105,7 @@ export const PublicationTimeLineChart = ({ data, widgetType, isDetailsPage = fal
         key={i}
         fill="#6689c6"
         x={xScaleHistogram(bucket.year) + BUCKET_PADDING / 2}
-        width={Math.abs(dateRange[1] - dateRange[0] == 0 ? 10 : boundsWidth / (dateRange[1] - dateRange[0]) - BUCKET_PADDING)}
+        width={Math.abs(dateRange[1] - dateRange[0] == 0 ? 10 : boundsWidth / (1 + dateRange[1] - dateRange[0]) - BUCKET_PADDING)}
         y={yScaleHistogram(bucket.count)}
         height={boundsHeight - yScaleHistogram(bucket.count)}
       />

--- a/src/components/widgets/PublicationTimeLineChart/index.tsx
+++ b/src/components/widgets/PublicationTimeLineChart/index.tsx
@@ -190,7 +190,7 @@ export const PublicationTimeLineChart = ({ data, widgetType, isDetailsPage = fal
           </g>
           <g width={boundsWidth} height={boundsHeight} ref={axesRef} transform={`translate(${[MARGIN.left, MARGIN.top].join(',')})`} />
         </svg>
-        <CustomSlider value={dateRange} minValue={minYear} maxValue={maxYear} step={10} handleSliderChange={handleSliderChange} />
+        <CustomSlider label="Adjust publication years on timeline" value={dateRange} minValue={minYear} maxValue={maxYear} step={10} handleSliderChange={handleSliderChange} />
       </Box>
     </>
   );

--- a/src/components/widgets/PublicationTimeLineChart/index.tsx
+++ b/src/components/widgets/PublicationTimeLineChart/index.tsx
@@ -76,7 +76,7 @@ export const PublicationTimeLineChart = ({ data, widgetType, isDetailsPage = fal
     svgElement.selectAll('*').remove();
 
     const xAxisGenerator = d3.axisBottom(xScaleHistogram);
-    const dateSpread = dateRange[1] - dateRange[0];
+    const dateSpread = dateRange[1] - dateRange[0] > 0 ? dateRange[1] - dateRange[0] : 1;
     if (dateSpread < 10) {
       xAxisGenerator.ticks(dateSpread).tickFormat((d) => Math.round(d));
     }
@@ -105,7 +105,7 @@ export const PublicationTimeLineChart = ({ data, widgetType, isDetailsPage = fal
         key={i}
         fill="#6689c6"
         x={xScaleHistogram(bucket.year) + BUCKET_PADDING / 2}
-        width={Math.abs(dateRange[1] - dateRange[0] == 0 ? 10 : boundsWidth / (1 + dateRange[1] - dateRange[0]) - BUCKET_PADDING)}
+        width={Math.abs(1 + dateRange[1] - dateRange[0] == 0 ? 10 : boundsWidth / (1 + dateRange[1] - dateRange[0]) - BUCKET_PADDING)}
         y={yScaleHistogram(bucket.count)}
         height={boundsHeight - yScaleHistogram(bucket.count)}
       />

--- a/src/layout/MainLayout/DashboardHeader/index.tsx
+++ b/src/layout/MainLayout/DashboardHeader/index.tsx
@@ -1,5 +1,6 @@
-import { useState } from 'react';
-import { Box, Stack, FormControl, Select, MenuItem, SelectChangeEvent, useTheme } from '@mui/material';
+import { useState, useMemo } from 'react';
+import { Box, FormControl, Select, MenuItem, SelectChangeEvent, useTheme, Typography, Grid } from '@mui/material';
+import useDashboardState from 'hooks/useDashboardState';
 
 const DashboardHeader = ({ csrfToken }: any) => {
   const theme = useTheme();
@@ -12,6 +13,7 @@ const DashboardHeader = ({ csrfToken }: any) => {
   ];
   const [widget1, setWidget1] = useState<string>(widgetList1[0]);
   const [widget2, setWidget2] = useState<string>(widgetList2[0]);
+  const { dashboardState } = useDashboardState();
 
   const handleChange = (event: SelectChangeEvent<string>) => {
     const { name, value } = event.target;
@@ -20,7 +22,26 @@ const DashboardHeader = ({ csrfToken }: any) => {
   };
 
   return (
-    <Stack
+    <Grid container
+      direction="row"
+      alignItems="center"
+      justifyContent="space-between"
+    >
+      <Grid item 
+        direction="row"
+        alignItems="center"
+        justifyContent="flex-start"
+      >
+        <Typography variant="h6" color="primary" sx={{ 
+            padding: theme.spacing(1.5)
+          }} 
+          justifyContent="flex-start"
+        >
+          Selected Workset Name:
+          <Typography sx={{ fontSize: "1rem", fontWeight: 600 }}>{dashboardState?.worksetInfo?.name}</Typography>
+        </Typography>
+      </Grid>
+      <Grid item 
       sx={{
         padding: theme.spacing(2),
         '& .MuiButton-root::after': { boxShadow: 'none' }
@@ -29,54 +50,55 @@ const DashboardHeader = ({ csrfToken }: any) => {
       alignItems="center"
       justifyContent="flex-end"
     >
-      <Box>
-        <FormControl sx={{ m: 1, mr: '25px' }}>
-          <Select
-            value={widget1}
-            name={'widget_1'}
-            sx={{
-              width: '11.875rem',
-              height: '1.5625rem',
-              padding: theme.spacing(0.25),
-              borderRadius: '0.815rem',
-              boxSizing: 'border-box',
-              fontSize: '0.8125rem'
-            }}
-            color="secondary"
-            onChange={handleChange}
-          >
-            <MenuItem value="Add Widgets">Add Widgets</MenuItem>
-            {widgetList1.map((item) => (
-              <MenuItem key={item} value={item}>
-                {item}
-              </MenuItem>
-            ))}
-          </Select>
-        </FormControl>
-        <FormControl sx={{ m: 1 }}>
-          <Select
-            value={widget2}
-            name={'widget_2'}
-            sx={{
-              width: '18.75rem',
-              height: '25px',
-              padding: '2px 2px 2px 2px',
-              borderRadius: '13px',
-              boxSizing: 'border-box',
-              fontSize: '13px'
-            }}
-            color="secondary"
-            onChange={handleChange}
-          >
-            {widgetList2.map((item) => (
-              <MenuItem key={item} value={item}>
-                {item}
-              </MenuItem>
-            ))}
-          </Select>
-        </FormControl>
-      </Box>
-    </Stack>
+        <Box>
+          <FormControl sx={{ m: 1, mr: '25px' }}>
+            <Select
+              value={widget1}
+              name={'widget_1'}
+              sx={{
+                width: '11.875rem',
+                height: '1.5625rem',
+                padding: theme.spacing(0.25),
+                borderRadius: '0.815rem',
+                boxSizing: 'border-box',
+                fontSize: '0.8125rem'
+              }}
+              color="secondary"
+              onChange={handleChange}
+            >
+              <MenuItem value="Add Widgets">Add Widgets</MenuItem>
+              {widgetList1.map((item) => (
+                <MenuItem key={item} value={item}>
+                  {item}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <FormControl sx={{ m: 1 }}>
+            <Select
+              value={widget2}
+              name={'widget_2'}
+              sx={{
+                width: '18.75rem',
+                height: '25px',
+                padding: '2px 2px 2px 2px',
+                borderRadius: '13px',
+                boxSizing: 'border-box',
+                fontSize: '13px'
+              }}
+              color="secondary"
+              onChange={handleChange}
+            >
+              {widgetList2.map((item) => (
+                <MenuItem key={item} value={item}>
+                  {item}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        </Box>
+      </Grid>
+    </Grid>
   );
 };
 


### PR DESCRIPTION
Fixed timeline y-axis getting overcrowded, x-axis duplicate ticks, final bar hanging outside the axis, and width of bar in case where only one year is displayed.

Added a minimum size that dots on the map can be so single values remain visible and selectable even when there is a large max value being displayed.

Date slider label is now passed by the component calling it, rather than being hardcoded within the slider itself.