### PR TITLE
Ht style

### DIFF
--- a/src/components/widgets/ChorloplethMap/index.tsx
+++ b/src/components/widgets/ChorloplethMap/index.tsx
@@ -58,7 +58,11 @@ export const ChorloplethMap = ({ data, widgetType, isDetailsPage = false }) => {
       .html(`<strong>Location: ${d.name}<br/> Contributors: ${d.population}</strong>`)
       .style('left', event.pageX + 10 + 'px')
       .style('top', event.pageY - 12 + 'px')
-      .style('position', 'absolute');
+      .style('position', 'absolute')
+      .style('font-family', 'Questrial, sans-serif') // Change 'YourChosenFont' to the desired font-family
+      .style('font-size', '16px')
+      .style('background-color', theme.palette.common.white)
+      .style('color', theme.palette.common.black);
   };
 
   const mapDataHistogram = useMemo(() => {

--- a/src/themes/theme/default.ts
+++ b/src/themes/theme/default.ts
@@ -33,7 +33,7 @@ const Default = (colors: PalettesProps): PaletteThemeProps => {
       lighter: '#73787A'/*blue[0]*/,
       100: blue[1],
       200: blue[2],
-      light: blue[3],
+      light: '#73787A'/*blue[3]*/, //change this to an orange hue
       400: blue[4],
       main: '#C35400'/*blue[5]*/,
       dark: '#73787A'/*blue[6]*/,


### PR DESCRIPTION
1. in src/components/widgets/ChorloplethMap/index.tsx I'm adding a few more .style() methods to specify a font-family, font-size, background color, and font color for the Chloropleth map widget's tooltips (seen when you hover over the plots on the map).
2. I change the primary theme object property values to an HT brand orange. 