### PR TITLE
Add dependabot configuration and update workflow events

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -116,11 +116,14 @@ jobs:
         with:
           token: ${{ secrets.PAT }}
           repository: htrc/torchlite-argocd
-          event-type: ${{ github.head_ref || github.ref_name }}_commit_frontend
+          event-type: argocd
           client-payload: >-
             {
               "image": "${{ fromJSON(steps.meta.outputs.json).tags[0] }}",
-              "commit_msg": ${{ env.HEAD_COMMIT_MESSAGE }}
+              "commit_msg": "[${{ github.head_ref || github.ref_name }}]: ${{ env.HEAD_COMMIT_MESSAGE }}",
+              "repository": "${{ github.event.repository.name }}",
+              "environment": "${{ github.event.inputs.environment }}",
+              "ref": "${{ github.head_ref || github.ref_name }}"
             }
       - name: Manual Repository Dispatch
         if: github.event.inputs.environment != ''
@@ -130,9 +133,12 @@ jobs:
         with:
           token: ${{ secrets.PAT }}
           repository: htrc/torchlite-argocd
-          event-type: ${{ github.event.inputs.environment }}_commit_frontend
+          event-type: argocd-manual
           client-payload: >-
             {
               "image": "${{ fromJSON(steps.meta.outputs.json).tags[0] }}",
-              "commit_msg": "Manual deployment by ${{ github.triggering_actor }}"
+              "commit_msg": "[${{ github.head_ref || github.ref_name }}]: Manual deployment by ${{ github.triggering_actor }}",
+              "repository": "${{ github.event.repository.name }}",
+              "environment": "${{ github.event.inputs.environment }}",
+              "ref": "${{ github.head_ref || github.ref_name }}"
             }


### PR DESCRIPTION
Configured dependabot to automatically check and maintain GitHub Actions dependencies on a daily basis. Also, updated the 'ci.yaml' workflow to use event type 'argocd' and 'argocd-manual', and included useful metadata to commit message payloads for both automated and manual deployments.