### PR TITLE
front-end clean the data bug fixes

### DIFF
--- a/src/layout/MainLayout/SideBar/CleanDataWidget.tsx
+++ b/src/layout/MainLayout/SideBar/CleanDataWidget.tsx
@@ -199,25 +199,26 @@ const handleChange = (event: React.ChangeEvent<HTMLInputElement>, checked: boole
 const handleSubItemChange = (subLabel: string, checked: boolean) => {
   setTypeGroup(prev =>
     prev.map(type => {
-      if (type.label === 'Page Features' && !checked) {
-        // If the "Page Features" box is unchecked, uncheck all sub-items
-        const updatedValue = type.value.map((item: any) => ({ ...item, checked: false }));
-        console.log("Returning updatedValue for unchecked 'Page Features' box:", updatedValue);
-        return { ...type, value: updatedValue };
-      } else if (type.label === 'Page Features' && checked) {
-        // If the "Page Features" box is checked, only update the sub-item that triggered the change
-        const updatedValue = type.value.map((item: any) =>
-          item.subLabel === subLabel ? { ...item, checked } : item
-        );
-        console.log("Returning updatedValue for checked 'Page Features' box:", updatedValue);
-        return { ...type, value: updatedValue };
+      if (type.label === 'Page Features') {
+        if (!checked && subLabel === 'Page Features') {
+          // If the "Page Features" parent box is unchecked, uncheck all sub-items
+          const updatedValue = type.value.map((item: any) => ({ ...item, checked: false }));
+          console.log("Returning updatedValue for unchecked 'Page Features' box:", updatedValue);
+          return { ...type, value: updatedValue };
+        } else {
+          // Only update the specific sub-item that triggered the change
+          const updatedValue = type.value.map((item: any) =>
+            item.subLabel === subLabel ? { ...item, checked } : item
+          );
+          console.log("Returning updatedValue for sub-item change:", updatedValue);
+          return { ...type, value: updatedValue };
+        }
       }
       console.log("Returning unchanged type:", type);
       return type;
     })
   );
 };
-
 
 const handleFilterChange = (selectedFilterOptions) => {
   const selectedValues = selectedFilterOptions.map(option => option.value);

--- a/src/sections/sidebar/CustomStopwordsModal.tsx
+++ b/src/sections/sidebar/CustomStopwordsModal.tsx
@@ -93,6 +93,8 @@ function CustomStopwordsModal ({open, onClose, onSaveName}: { open: boolean, onC
       setUrlError("");
   };
 
+  const isSaveEnabled = stopwordsName.trim() !== "" && (filePath.trim() !== "" || (url.trim() !== "" && urlError === ""));
+
     return (
         <Modal open={open} onClose={handleClose}>
             <Box sx={style}>
@@ -172,7 +174,7 @@ function CustomStopwordsModal ({open, onClose, onSaveName}: { open: boolean, onC
                         color="primary" 
                         sx={{ minWidth: '100px'}} 
                         onClick={handleSave} 
-                        disabled={(filePath === "" && url === "")}>
+                        disabled={!isSaveEnabled}>
                           Save
                       </Button>
                     </Grid>


### PR DESCRIPTION
Two 'Clean the Date' bugs were identified by Deren and have been fixed here: the 'Save' button on the upload stopwords modal would enable if the user either uploaded a file or input a correct URL, but did NOT provide a list name; and the child sub-item options in the 'Page Features' were all unchecking if the user simply unchecked one sub-item checkbox. Now the 'Save' button only enables if a title has been provided and an option has been correctly chosen, and now all the sub-item checkboxes operate independently from one another.