### PR TITLE
Share private worksets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Max public or user workset size dropped to 400 volumes. [#78](https://github.com/htrc/torchlite-app/issues/78) 
 
 ### Fixed
-- Error handling for unauthorized or non-existent workset, should now throw meaningful error
+- Error handling for unauthorized or non-existent workset, should now throw meaningful error [#146](https://github.com/htrc/torchlite-backend/issues/146)
 
 ## [0.2.2] – 2025-02-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3] – 2025-02-26
+
 ### Changed
 - Names of some widgets and workset sections. [#85](https://github.com/htrc/torchlite-app/issues/85)
 - Max public or user workset size dropped to 400 volumes. [#78](https://github.com/htrc/torchlite-app/issues/78) 
@@ -46,7 +48,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - This CHANGELOG file.
 - Share button and popup [#61](https://github.com/htrc/torchlite-app/issues/61)
 
-[unreleased]: https://github.com/htrc/torchlite-frontend/compare/0.2.2...HEAD
+[unreleased]: https://github.com/htrc/torchlite-frontend/compare/0.2.3...HEAD
+[0.2.3]: https://github.com/htrc/torchlite-frontend/compare/0.2.2...0.2.3
 [0.2.2]: https://github.com/htrc/torchlite-frontend/compare/0.2.1...0.2.2
 [0.2.1]: https://github.com/htrc/torchlite-frontend/compare/0.2.0...0.2.1
 [0.2.0]: https://github.com/htrc/torchlite-frontend/compare/0.1.0...0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Names of some widgets and workset sections. [#85](https://github.com/htrc/torchlite-app/issues/85)
+- Max public or user workset size dropped to 400 volumes. [#78](https://github.com/htrc/torchlite-app/issues/78) 
+
+### Fixed
+- Error handling for unauthorized or non-existent workset, should now throw meaningful error
+
 ## [0.2.2] – 2025-02-12
 
 ### Fixed

--- a/src/contexts/AppContext.tsx
+++ b/src/contexts/AppContext.tsx
@@ -56,10 +56,10 @@ function AppProvider({ children }: AppProviderProps) {
         // Get worksets
         let worksets: WorksetList = await getAvailableWorksets();
         if (worksets?.public) {
-          worksets.public = worksets.public.filter((workset) => workset.numVolumes < 1000)
+          worksets.public = worksets.public.filter((workset) => workset.numVolumes < 400)
         }
         if (worksets?.user) {
-          worksets.user = worksets.user.filter((workset) => workset.numVolumes < 1000)
+          worksets.user = worksets.user.filter((workset) => workset.numVolumes < 400)
         }
         setAvailableWorksets(worksets);
 

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -19,10 +19,10 @@ export const WidgetInfoLinks: any = {
 };
 
 export const WidgetTitles: any = {
-  MappingContributorData: 'Mapping Contributor Data',
+  MappingContributorData: 'Mapping Creator Birthplaces',
   PublicationDateTimeline: 'Publication Date Timeline',
-  Summary: 'Summary',
-  SimpleTagCloud: 'Simple Word Cloud'
+  Summary: 'Workset Summary',
+  SimpleTagCloud: 'Word Frequency Cloud'
 };
 
 export const TableColumns: any = {

--- a/src/layout/MainLayout/SideBar/WorksetWidget.tsx
+++ b/src/layout/MainLayout/SideBar/WorksetWidget.tsx
@@ -81,7 +81,7 @@ const WorksetWidget = () => {
       <Stack sx={{ margin: theme.spacing(1) }} spacing={2}>
         <FormControl sx={{ minWidth: 120 }}>
           <Select value={type} color="secondary" onChange={handleChange}>
-            <MenuItem value={'featured'}>Recommended Worksets</MenuItem>
+            <MenuItem value={'featured'}>Featured Worksets</MenuItem>
             <MenuItem value={'public'}>All Worksets</MenuItem>
             {availableWorksets?.user?.length ? <MenuItem value={'user'}>My Worksets</MenuItem> : <></>}
           </Select>

--- a/src/pages/api/dashboards/[id]/index.ts
+++ b/src/pages/api/dashboards/[id]/index.ts
@@ -55,7 +55,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         break;
     }
   } catch (err: any) {
-    console.log(typeof err);
+    console.log(err);
     if (err.status == 400) {
       res.status(400).end();
     }

--- a/src/pages/api/dashboards/[id]/index.ts
+++ b/src/pages/api/dashboards/[id]/index.ts
@@ -51,11 +51,16 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         if (isValidBody<DashboardStatePatch>(req.body, DashboardStatePatchSchema)) {
           await patchDashboard(dashboardId, req.body, headers);
           res.status(204).end();
-        } else return res.status(400).end();
+        }
         break;
     }
-  } catch (err) {
-    console.error(err);
-    res.status(500).json({ message: 'Internal server error' });
+  } catch (err: any) {
+    console.log(typeof err);
+    if (err.status == 400) {
+      res.status(400).end();
+    }
+    else {
+      res.status(500).json({ message: 'Internal server error' });
+    }
   }
 }

--- a/src/pages/api/dashboards/[id]/index.ts
+++ b/src/pages/api/dashboards/[id]/index.ts
@@ -55,7 +55,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         break;
     }
   } catch (err: any) {
-    console.log("HERE");
     console.log(typeof err);
     if (err.status == 400) {
       res.status(400).end();

--- a/src/pages/api/dashboards/[id]/index.ts
+++ b/src/pages/api/dashboards/[id]/index.ts
@@ -55,6 +55,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         break;
     }
   } catch (err: any) {
+    console.log("HERE");
     console.log(typeof err);
     if (err.status == 400) {
       res.status(400).end();

--- a/src/utils/axios.ts
+++ b/src/utils/axios.ts
@@ -28,7 +28,7 @@ axiosServices.interceptors.response.use(
         })
       );
     }
-    return Promise.reject((error.response && error.response.data) || 'Wrong Services');
+    return Promise.reject((error.response && {data: error.response.data, status: error.response.status}) || 'Wrong Services');
   }
 );
 


### PR DESCRIPTION
Trying to access worksets the user is not authorized to access (such as from a shared link to a private workset, or logging out while working with a private workset), or an invalid workset id have been causing crashes of the frontend for not correctly handling the error type. Now these cases should return an HTTP 400 error, which could be used to create a meaningful error message for users, instead of the generic 500 error which we were getting before. Error logs on the server side should now be a bit more informative too.

Also renamed a few parts of the front-end, and limited public and user worksets from AG to 400 volumes.